### PR TITLE
Fix type for Event.Contexts.

### DIFF
--- a/events.go
+++ b/events.go
@@ -73,7 +73,7 @@ type Event struct {
 	Entries         *[]Entry                `json:"entries,omitempty"`
 	Packages        *map[string]string      `json:"packages,omitempty"`
 	SDK             *map[string]interface{} `json:"sdk,omitempty"`
-	Contexts        *map[string]string      `json:"contexts,omitempty"`
+	Contexts        *map[string]interface{} `json:"contexts,omitempty"`
 	Context         *map[string]interface{} `json:"context,omitempty"`
 	Release         *Release                `json:"release,omitempty"`
 	GroupID         *string                 `json:"groupID,omitempty"`


### PR DESCRIPTION
[Bug] according to the [API document](https://docs.sentry.io/development/sdk-dev/interfaces/contexts/), the value for each known KV pair in `Event.contexts` is represented as a nested dictionary and any uncommon field can either be a dictionary or a plain string, therefore the value type has to be `interface{}`.  CLA signed.
