### PR TITLE
Adding VerifySSL to Project options

### DIFF
--- a/project.go
+++ b/project.go
@@ -43,6 +43,7 @@ type Project struct {
 	Organization       *Organization           `json:"organization,omitempty"`
 	DigestMinDelay     *int                    `json:"digestMinDelay,omitempty"`
 	DigestMaxDelay     *int                    `json:"digestMaxDelay,omitempty"`
+	VerifySSL          *bool                   `json:"verifySSL,omitempty"`
 }
 
 // CreateProject will create a new project in your org and team


### PR DESCRIPTION
Adding `verifySSL` to the Project struct so that the property unmarshals the property from https://docs.sentry.io/api/projects/get-project-details/.