### PR TITLE
Add required query param "resolution" in stats resource

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -27,6 +27,11 @@ func (o *statRequest) ToQueryString() string {
 	query.Add("stat", string(o.Stat))
 	query.Add("since", strconv.FormatInt(o.Since, 10))
 	query.Add("until", strconv.FormatInt(o.Until, 10))
+	
+	if o.Resolution != nil {
+	    query.Add("resolution", string(*o.Resolution))
+	}
+	
 	return query.Encode()
 }
 


### PR DESCRIPTION
Bug fix for API resource https://docs.sentry.io/api/projects/get-project-stats/
If make a request without a parameter "resolution", an error with 500 code will be received in response