### PR TITLE
add SetClientKeyRateLimit

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -14,12 +14,19 @@ type DSN struct {
 
 // Key is a DSN that sentry has made
 type Key struct {
-	Label       string    `json:"label,omitempty"`
-	DSN         DSN       `json:"dsn,omitempty"`
-	Secret      string    `json:"secret,omitempty"`
-	ID          string    `json:"id,omitempty"`
-	DateCreated time.Time `json:"dateCreated,omitempty"`
-	Public      string    `json:"public,omitempty"`
+	Label       string        `json:"label,omitempty"`
+	DSN         DSN           `json:"dsn,omitempty"`
+	Secret      string        `json:"secret,omitempty"`
+	ID          string        `json:"id,omitempty"`
+	DateCreated time.Time     `json:"dateCreated,omitempty"`
+	Public      string        `json:"public,omitempty"`
+	RateLimit   *KeyRateLimit `json:"rateLimit,omitempty"`
+}
+
+// KeyRateLimit is the rate limit for a DSN
+type KeyRateLimit struct {
+	Count  int `json:"count"`
+	Window int `json:"window"`
 }
 
 type nameReq struct {
@@ -56,4 +63,12 @@ func (c *Client) GetClientKeys(o Organization, p Project) ([]Key, error) {
 	var keys []Key
 	err := c.do("GET", fmt.Sprintf("projects/%s/%s/keys", *o.Slug, *p.Slug), &keys, nil)
 	return keys, err
+}
+
+// SetClientKeyRateLimit updates the rate limit only of a key. window is in seconds.
+func (c *Client) SetClientKeyRateLimit(o Organization, p Project, k Key, count, window int) (Key, error) {
+	var key Key
+	req := &Key{RateLimit: &KeyRateLimit{Count: count, Window: window}}
+	err := c.do("PUT", fmt.Sprintf("project/%s/%s/keys/%s", *o.Slug, *p.Slug, k.ID), &key, &req)
+	return key, err
 }

--- a/keys_test.go
+++ b/keys_test.go
@@ -28,6 +28,9 @@ func TestKeysResource(t *testing.T) {
 		if key.Label != "Test client key" {
 			t.Error("Key does not have correct label")
 		}
+		if key.RateLimit != nil {
+			t.Error("freshly created keys should not have rate limiting")
+		}
 		t.Run("List client keys", func(t *testing.T) {
 			keys, err := client.GetClientKeys(org, project)
 			if err != nil {
@@ -35,6 +38,18 @@ func TestKeysResource(t *testing.T) {
 			}
 			if len(keys) != 2 {
 				t.Errorf("Expected 2 keys, got %d", len(keys))
+			}
+		})
+		t.Run("Update rate limit for client key", func(t *testing.T) {
+			resKey, err := client.SetClientKeyRateLimit(org, project, key, 1000, 60)
+			if err != nil {
+				t.Error(err)
+			}
+			if resKey.RateLimit == nil {
+				t.Error("missing rate limit in updated key")
+			}
+			if resKey.RateLimit.Count != 1000 || resKey.RateLimit.Window != 60 {
+				t.Error("failed to apply rate limit for key")
 			}
 		})
 		t.Run("Update name of client key", func(t *testing.T) {


### PR DESCRIPTION
to set the per client key rate limit.

Signed-off-by: Hanno Hecker <hanno@zalando.de>