### PR TITLE
Add ability to parse 14 days of issue stats

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -27,6 +27,7 @@ type Status string
 // IssueStats is the stats of a issue
 type IssueStats struct {
 	TwentyFourHour *[]Stat `json:"24h,omitempty"`
+	FourteenDays   *[]Stat `json:"14d,omitempty"`
 	ThirtyDays     *[]Stat `json:"30d,omitempty"`
 }
 

--- a/issue_test.go
+++ b/issue_test.go
@@ -72,6 +72,22 @@ func TestIssueResource(t *testing.T) {
 			t.Error("Should be no new results")
 		}
 
+		t.Run("Get issues with statsPeriod of 14 days", func(t *testing.T) {
+			period := "14d"
+			issues, _, err := client.GetIssues(org, project, &period, nil, nil)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(issues) <= 0 {
+				t.Fatal("No issues found for this project")
+			}
+			for _, issue := range issues {
+				if issue.Stats.FourteenDays == nil {
+					t.Fatal("We should be able to get 14 days of stats for this issue but didn't.")
+				}
+			}
+		})
+
 		t.Run("Get hashes for issue", func(t *testing.T) {
 			hashes, link, err := client.GetIssueHashes(issues[0])
 			if err != nil {


### PR DESCRIPTION
When retrieving project issues over 14 days (`statsPeriod=14d`), the stats returned cannot be parsed as the existing `IssueStats` struct only handles `24h` and `30d`.

This PR adds a field to the `IssueStats` struct so that the `14d` stats can be parsed.