### PR TITLE
Fix type for Issue.Metadata (closes #33)

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -96,7 +96,7 @@ type Issue struct {
 	LastSeen            *time.Time              `json:"lastSeen,omitempty"`
 	Level               *string                 `json:"level,omitempty"`
 	Logger              *string                 `json:"logger,omitempty"`
-	Metadata            *map[string]string      `json:"metadata,omitempty"`
+	Metadata            *map[string]interface{} `json:"metadata,omitempty"`
 	NumComments         *int                    `json:"numComments,omitempty"`
 	Permalink           *string                 `json:"permalink,omitempty"`
 	Project             *Project                `json:"project,omitempty"`


### PR DESCRIPTION
It seems the change hasn't been documented in https://docs.sentry.io/api/events/retrieve-an-issue/ .  Closes #33. CLA signed (See #13.)
