### PR TITLE
Adjust issue events endpoint

### DIFF
--- a/events.go
+++ b/events.go
@@ -65,7 +65,7 @@ type Event struct {
 	Size            *int                    `json:"size,omitempty"`
 	Platform        *string                 `json:"platform,omitempty"`
 	Type            *string                 `json:"type,omitempty"`
-	Metadata        *map[string]string      `json:"metadata,omitempty"`
+	Metadata        *map[string]interface{} `json:"metadata,omitempty"`
 	Tags            *[]Tag                  `json:"tags,omitempty"`
 	DateCreated     *time.Time              `json:"dateCreated,omitempty"`
 	DateReceived    *time.Time              `json:"dateReceived,omitempty"`

--- a/issue.go
+++ b/issue.go
@@ -134,6 +134,19 @@ func (i *issueQuery) ToQueryString() string {
 	return query.Encode()
 }
 
+type issueEventQuery struct {
+	Full *bool
+}
+
+func (e *issueEventQuery) ToQueryString() string {
+	query := url.Values{}
+	if e.Full != nil {
+		query.Add("full", strconv.FormatBool(*e.Full))
+	}
+
+	return query.Encode()
+}
+
 //GetIssues will fetch all issues for organization and project
 func (c *Client) GetIssues(o Organization, p Project, StatsPeriod *string, ShortIDLookup *bool, query *string) ([]Issue, *Link, error) {
 	var issues []Issue
@@ -185,9 +198,15 @@ func (c *Client) GetIssueTagValues(i Issue, tag IssueTag) ([]IssueTagValue, *Lin
 }
 
 //GetIssueEvents will fetch all events for a issue
-func (c *Client) GetIssueEvents(i Issue) ([]Event, *Link, error) {
+func (c *Client) GetIssueEvents(i Issue, full *bool) ([]Event, *Link, error) {
 	var events []Event
-	link, err := c.doWithPagination("GET", fmt.Sprintf("issues/%s/events", *i.ID), &events, nil)
+
+	issueEventFilter := &issueEventQuery{
+		Full: full,
+	}
+
+	link, err := c.doWithPaginationQuery(
+		"GET", fmt.Sprintf("issues/%s/events", *i.ID), &events, nil, issueEventFilter)
 	return events, link, err
 }
 

--- a/issue_test.go
+++ b/issue_test.go
@@ -113,7 +113,18 @@ func TestIssueResource(t *testing.T) {
 		})
 
 		t.Run("Get events for this issue", func(t *testing.T) {
-			events, _, err := client.GetIssueEvents(issues[0])
+			events, _, err := client.GetIssueEvents(issues[0], nil)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(events) == 0 {
+				t.Errorf("Should be at least more than 1 event %v", events)
+			}
+		})
+
+		t.Run("Get events for this issue with all details", func(t *testing.T) {
+			full := true
+			events, _, err := client.GetIssueEvents(issues[0], &full)
 			if err != nil {
 				t.Error(err)
 			}

--- a/userfeedback_test.go
+++ b/userfeedback_test.go
@@ -29,7 +29,7 @@ func TestUserFeedbackResource(t *testing.T) {
 
 		issue := issues[0]
 
-		events, _, _ := client.GetIssueEvents(issue)
+		events, _, _ := client.GetIssueEvents(issue, nil)
 		if len(events) == 0 {
 			t.Fatal("no events found")
 		}


### PR DESCRIPTION
Hi,

Was willing to get issue events with all information as specified on https://docs.sentry.io/api/events/list-an-issues-events/ but it requires a query parameter.

Since not present into your lib I just added it accordingly. Note that I took as example what you did on `GetIssues()` so it includes a breaking change about the method signature (but should be fine to keep the lib consistent).

(I added also the same as for #35 but to the Event struct)

Thank you :)